### PR TITLE
Add MCP_NPX_WRAPPER to claude_desktop_config.json instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,9 @@ To use MCP Docs Service with Claude Desktop:
     "docs-manager": {
       "command": "npx",
       "args": ["-y", "mcp-docs-service", "/path/to/your/docs"]
+      "env": {
+        "MCP_NPX_WRAPPER": true
+      }
     }
   }
 }


### PR DESCRIPTION
I got some annoying error pop ups such as these upon starting Claude desktop: `Client error for command Unexpected token 'M', "MCP Docume"... is not valid JSON`. These are also mentioned in https://github.com/alekspetrov/mcp-docs-service/issues/1.

Saw in the code that the MCP_NPX_WRAPPER env var fixes this. This PR adds it to the README instruction.

PS: Thanks for this tool! I'm not using it for code documentation per se but as a simple CMS, and it's a giant productivity boost.